### PR TITLE
[#171404935] Bump to rebase on 74.14.0

### DIFF
--- a/jobs/uaa/templates/bin/uaa
+++ b/jobs/uaa/templates/bin/uaa
@@ -19,7 +19,7 @@ KEYSTORE_OPTS="-Djavax.net.ssl.trustStore=$KEYSTORE -Djavax.net.ssl.trustStoreTy
 log "Keystore configured to: $KEYSTORE"
 
 export PATH="/var/vcap/packages/uaa/jdk/bin:$PATH"
-export JAVA_OPTS="-DPID=$$ -Dnetworkaddress.cache.ttl=0 $HTTP_PROXY_JAVA_OPTIONS $NEWRELIC_OPTS $KEYSTORE_OPTS"
+export JAVA_OPTS="-Djava.security.egd=file:/dev/./urandom -DPID=$$ -Dnetworkaddress.cache.ttl=0 $HTTP_PROXY_JAVA_OPTIONS $NEWRELIC_OPTS $KEYSTORE_OPTS"
 
 log "Calling Tomcat start up command"
 /var/vcap/packages/uaa/tomcat/bin/catalina.sh run &


### PR DESCRIPTION
What
---
Targets the `src/uaa` submodule at the head of `gds_master`, in order to package our newly-rebased fork, from https://github.com/alphagov/paas-uaa/pull/17

How to review
---
Check the submodule points to the head commit on [`gds_master`](https://github.com/alphagov/paas-uaa/commits/gds_master). 

Who can review
---
Anyone, really.