### PR TITLE
Add `LOG4J_FORMAT_MSG_NO_LOOKUPS` env var to mitigate CVE-2021-44228

### DIFF
--- a/jobs/uaa/templates/bin/uaa
+++ b/jobs/uaa/templates/bin/uaa
@@ -29,6 +29,8 @@ log "Keystore configured to: $KEYSTORE"
 export PATH="/var/vcap/packages/uaa/jdk/bin:$PATH"
 export JAVA_OPTS="-Djava.security.egd=file:/dev/./urandom -DPID=$$ -Dnetworkaddress.cache.ttl=0 $HTTP_PROXY_JAVA_OPTIONS $NEWRELIC_OPTS $KEYSTORE_OPTS -Dlog4j.configurationFile=/var/vcap/jobs/uaa/config/log4j2.properties"
 
+export LOG4J_FORMAT_MSG_NO_LOOKUPS=true
+
 log "Calling Tomcat start up command"
 /var/vcap/packages/uaa/tomcat/bin/catalina.sh run &
 CATALINA_PID=$!


### PR DESCRIPTION
Setting the `LOG4J_FORMAT_MSG_NO_LOOKUPS` env var to `true` will mitigate the
exploit, because we're running log4j 2.13.3[1]

[1] https://logging.apache.org/log4j/2.x/security.html